### PR TITLE
adds GN

### DIFF
--- a/data/eda.ipynb
+++ b/data/eda.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -27,7 +27,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -38,6 +38,7 @@
     "    in_edge_index = data[\"edge_index\"][np.isin(data[\"edge_index\"], data[\"node_config_ids\"]).any(1)]\n",
     "\n",
     "    in_node_ids = np.unique(in_edge_index)\n",
+    "    assert len(set(data[\"node_config_ids\"]) - set(in_node_ids)) == 0\n",
     "    lookup = np.ones(data[\"node_feat\"].shape[0]) * -1\n",
     "    lookup[in_node_ids] = np.arange(in_node_ids.shape[0])\n",
     "\n",
@@ -56,7 +57,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -76,9 +77,1301 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loading train data...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "  0%|          | 0/61 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/mlperf_transformer.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 13502 nodes and 22209 edges\n",
+      "New graph has 2143 nodes and 2137 edges\n",
+      "Removing 384 duplicated node configs out of 5192\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "  2%|▏         | 1/61 [00:00<00:39,  1.52it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/ncf.2x2.fp32.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 490 nodes and 729 edges\n",
+      "New graph has 65 nodes and 56 edges\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "  3%|▎         | 2/61 [00:18<10:50, 11.03s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Removing 99053 duplicated node configs out of 100040\n",
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/brax_es.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 4185 nodes and 7209 edges\n",
+      "New graph has 224 nodes and 200 edges\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "  5%|▍         | 3/61 [00:37<14:05, 14.57s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Removing 86479 duplicated node configs out of 100040\n",
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/mask_rcnn_batch_16_bf16_img1024.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 13342 nodes and 21709 edges\n",
+      "New graph has 1820 nodes and 1622 edges\n",
+      "Removing 241 duplicated node configs out of 4999\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "  7%|▋         | 4/61 [00:38<08:33,  9.02s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/resnet_v1_50_official_batch_128_f32.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 5809 nodes and 10345 edges\n",
+      "New graph has 594 nodes and 599 edges\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "  8%|▊         | 5/61 [00:38<05:30,  5.89s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Removing 868 duplicated node configs out of 9224\n",
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/mnasnet_a1_batch_128.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 8847 nodes and 14797 edges\n",
+      "New graph has 811 nodes and 806 edges\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 10%|▉         | 6/61 [00:38<03:38,  3.98s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Removing 313 duplicated node configs out of 5408\n",
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/bert_classifier.2x2.fp32.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 40332 nodes and 71912 edges\n",
+      "New graph has 7304 nodes and 6804 edges\n",
+      "Removing 667 duplicated node configs out of 11152\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 11%|█▏        | 7/61 [00:42<03:25,  3.81s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/mlperf_nmt_batch_64.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 15809 nodes and 25564 edges\n",
+      "New graph has 3884 nodes and 3400 edges\n",
+      "Removing 2971 duplicated node configs out of 10776\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 13%|█▎        | 8/61 [00:44<02:47,  3.17s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/resnet_v2_50_batch_16.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 5162 nodes and 9160 edges\n",
+      "New graph has 535 nodes and 550 edges\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 15%|█▍        | 9/61 [00:45<02:07,  2.46s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Removing 2840 duplicated node configs out of 17632\n",
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/resnet_v1_50_official_batch_32_bf16.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 6136 nodes and 10670 edges\n",
+      "New graph has 488 nodes and 493 edges\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 16%|█▋        | 10/61 [00:45<01:36,  1.88s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Removing 1922 duplicated node configs out of 12984\n",
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/resnet_v2_200_batch_64.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 19662 nodes and 35460 edges\n",
+      "New graph has 2085 nodes and 2100 edges\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 18%|█▊        | 11/61 [00:46<01:14,  1.48s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Removing 926 duplicated node configs out of 6288\n",
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/retinanet.2x2.fp32.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 13867 nodes and 22162 edges\n",
+      "New graph has 995 nodes and 1045 edges\n",
+      "Removing 817 duplicated node configs out of 6558\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 20%|█▉        | 12/61 [00:46<00:56,  1.15s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/inference_mlperf_ssd_1200_batch_128.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 24790 nodes and 32709 edges\n",
+      "New graph has 6411 nodes and 4774 edges\n",
+      "Removing 1103 duplicated node configs out of 6228\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 21%|██▏       | 13/61 [00:48<01:01,  1.29s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/transformer.4x4.fp16.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 7324 nodes and 12087 edges\n",
+      "New graph has 1067 nodes and 1230 edges\n",
+      "Removing 1925 duplicated node configs out of 25240\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 23%|██▎       | 14/61 [00:50<01:17,  1.65s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/tf2_bert_squad_dynamic.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 21196 nodes and 37779 edges\n",
+      "New graph has 3848 nodes and 3395 edges\n",
+      "Removing 1675 duplicated node configs out of 18992\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 25%|██▍       | 15/61 [00:54<01:40,  2.19s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/resnet50.8x8.fp32.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 5345 nodes and 8775 edges\n",
+      "New graph has 599 nodes and 601 edges\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 26%|██▌       | 16/61 [00:54<01:15,  1.67s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Removing 1840 duplicated node configs out of 11400\n",
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/inference_mlperf_resnet_batch_16.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 1111 nodes and 1557 edges\n",
+      "New graph has 215 nodes and 164 edges\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 28%|██▊       | 17/61 [00:59<01:52,  2.55s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Removing 46315 duplicated node configs out of 48288\n",
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/inception_v2_batch_128_train.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 8836 nodes and 15567 edges\n",
+      "New graph has 768 nodes and 782 edges\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 30%|██▉       | 18/61 [00:59<01:21,  1.89s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Removing 841 duplicated node configs out of 7592\n",
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/resnet50.8x8.fp16.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 5605 nodes and 9018 edges\n",
+      "New graph has 476 nodes and 483 edges\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 31%|███       | 19/61 [00:59<01:00,  1.45s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Removing 1400 duplicated node configs out of 10528\n",
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/resnet_v2_50_batch_128.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 5162 nodes and 9160 edges\n",
+      "New graph has 535 nodes and 550 edges\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 33%|███▎      | 20/61 [01:00<00:46,  1.12s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Removing 719 duplicated node configs out of 9176\n",
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/magenta_dynamic.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 650 nodes and 1100 edges\n",
+      "New graph has 180 nodes and 139 edges\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 34%|███▍      | 21/61 [01:18<04:14,  6.36s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Removing 89075 duplicated node configs out of 100040\n",
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/resnet50.4x4.bf16.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 5605 nodes and 9018 edges\n",
+      "New graph has 476 nodes and 483 edges\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 36%|███▌      | 22/61 [01:19<02:57,  4.55s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Removing 622 duplicated node configs out of 8552\n",
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/bert_pretraining.2x2.fp16.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 21338 nodes and 37243 edges\n",
+      "New graph has 3538 nodes and 3283 edges\n",
+      "Removing 2056 duplicated node configs out of 19096\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 38%|███▊      | 23/61 [01:22<02:42,  4.27s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/xception_imagenet.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 4748 nodes and 8547 edges\n",
+      "New graph has 766 nodes and 834 edges\n",
+      "Removing 1490 duplicated node configs out of 15656\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 39%|███▉      | 24/61 [01:23<02:02,  3.30s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/resnet_v2_152_batch_64.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 15022 nodes and 27044 edges\n",
+      "New graph has 1589 nodes and 1604 edges\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 41%|████      | 25/61 [01:24<01:29,  2.49s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Removing 1065 duplicated node configs out of 7576\n",
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/bert_classifier.2x2.fp32.performance.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 20665 nodes and 36659 edges\n",
+      "New graph has 3633 nodes and 3380 edges\n",
+      "Removing 2342 duplicated node configs out of 22496\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 43%|████▎     | 26/61 [01:28<01:45,  3.01s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/magenta.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 12062 nodes and 21268 edges\n",
+      "New graph has 2424 nodes and 2518 edges\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 44%|████▍     | 27/61 [01:34<02:11,  3.85s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Removing 36349 duplicated node configs out of 40024\n",
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/shapemask.4x4.fp32.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 19348 nodes and 30351 edges\n",
+      "New graph has 1756 nodes and 1767 edges\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 46%|████▌     | 28/61 [01:35<01:34,  2.87s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Removing 231 duplicated node configs out of 5471\n",
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/resnet50_3d.2x2.bf16.npz\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 48%|████▊     | 29/61 [01:35<01:06,  2.07s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Pruning graph...\n",
+      "Original graph has 6656 nodes and 10799 edges\n",
+      "New graph has 623 nodes and 612 edges\n",
+      "Removing 1041 duplicated node configs out of 5304\n",
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/mask_rcnn_batch_4_bf16_img1408.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 12565 nodes and 20569 edges\n",
+      "New graph has 1660 nodes and 1508 edges\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 49%|████▉     | 30/61 [01:35<00:49,  1.61s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Removing 246 duplicated node configs out of 5820\n",
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/inference_mlperf_ssd_1200_batch_2.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 24793 nodes and 32713 edges\n",
+      "New graph has 6417 nodes and 4779 edges\n",
+      "Removing 2046 duplicated node configs out of 13216\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 51%|█████     | 31/61 [01:39<01:05,  2.19s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/inference_mlperf_resnet_batch_256.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 1111 nodes and 1557 edges\n",
+      "New graph has 215 nodes and 164 edges\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 52%|█████▏    | 32/61 [01:41<01:04,  2.23s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Removing 17409 duplicated node configs out of 34200\n",
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/tf2_bert_pretrain_dynamic_sequence_length.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 22385 nodes and 39976 edges\n",
+      "New graph has 4023 nodes and 3532 edges\n",
+      "Removing 1683 duplicated node configs out of 18200\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 54%|█████▍    | 33/61 [01:45<01:12,  2.58s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/resnet_v2_101_batch_128.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 10092 nodes and 18102 edges\n",
+      "New graph has 1062 nodes and 1077 edges\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 56%|█████▌    | 34/61 [01:45<00:52,  1.94s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Removing 640 duplicated node configs out of 7688\n",
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/efficientnet_b7_eval_batch_1.npz\n",
+      "Pruning graph...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 57%|█████▋    | 35/61 [01:45<00:37,  1.44s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Original graph has 43615 nodes and 73881 edges\n",
+      "New graph has 3142 nodes and 3089 edges\n",
+      "Removing 324 duplicated node configs out of 1960\n",
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/transformer_tf2_dynamic_shape.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 14680 nodes and 23604 edges\n",
+      "New graph has 2964 nodes and 2521 edges\n",
+      "Removing 992 duplicated node configs out of 11960\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 59%|█████▉    | 36/61 [01:47<00:37,  1.51s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/resnet50.8x16.fp16.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 5673 nodes and 9099 edges\n",
+      "New graph has 493 nodes and 495 edges\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 61%|██████    | 37/61 [01:48<00:29,  1.23s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Removing 2164 duplicated node configs out of 12912\n",
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/resnet_v2_152_batch_128.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 15022 nodes and 27044 edges\n",
+      "New graph has 1589 nodes and 1604 edges\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 62%|██████▏   | 38/61 [01:48<00:22,  1.00it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Removing 515 duplicated node configs out of 6488\n",
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/mlperf_resnet_batch_128_1_shard.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 8636 nodes and 14661 edges\n",
+      "New graph has 1188 nodes and 1086 edges\n",
+      "Removing 1046 duplicated node configs out of 12048\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 64%|██████▍   | 39/61 [01:49<00:21,  1.03it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/retinanet.4x4.bf16.performance.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 10449 nodes and 16824 edges\n",
+      "New graph has 1024 nodes and 1084 edges\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 66%|██████▌   | 40/61 [01:49<00:16,  1.29it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Removing 1150 duplicated node configs out of 5688\n",
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/mlperf_resnet.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 9257 nodes and 15281 edges\n",
+      "New graph has 1188 nodes and 1086 edges\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 67%|██████▋   | 41/61 [01:50<00:15,  1.30it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Removing 912 duplicated node configs out of 11104\n",
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/mask_rcnn_resnet50.4x4.bf16.performance.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 15748 nodes and 23128 edges\n",
+      "New graph has 3829 nodes and 3095 edges\n",
+      "Removing 261 duplicated node configs out of 4692\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 69%|██████▉   | 42/61 [01:51<00:15,  1.27it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/unet3d.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 2774 nodes and 4730 edges\n",
+      "New graph has 168 nodes and 168 edges\n",
+      "Removing 478 duplicated node configs out of 1159\n",
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/resnet50.4x4.bf16.performance.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 5689 nodes and 9131 edges\n",
+      "New graph has 476 nodes and 483 edges\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 72%|███████▏  | 44/61 [01:51<00:08,  1.99it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Removing 649 duplicated node configs out of 8560\n",
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/mlperf_ssd_2_shard_batch_8_fast_epoch.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 5670 nodes and 10166 edges\n",
+      "New graph has 933 nodes and 1030 edges\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 74%|███████▍  | 45/61 [01:52<00:07,  2.06it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Removing 718 duplicated node configs out of 6797\n",
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/bert_squad.2x2.fp32.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 39452 nodes and 70171 edges\n",
+      "New graph has 6990 nodes and 6516 edges\n",
+      "Removing 877 duplicated node configs out of 9816\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 75%|███████▌  | 46/61 [01:55<00:17,  1.16s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/transformer.2x2.fp32.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 7324 nodes and 12087 edges\n",
+      "New graph has 1067 nodes and 1230 edges\n",
+      "Removing 2068 duplicated node configs out of 27024\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 77%|███████▋  | 47/61 [01:57<00:22,  1.59s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/inception_v3_batch_8_train.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 12069 nodes and 21320 edges\n",
+      "New graph has 1059 nodes and 1084 edges\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 79%|███████▊  | 48/61 [01:58<00:16,  1.29s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Removing 2821 duplicated node configs out of 10016\n",
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/resnet50.2x2.fp16.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 5673 nodes and 9099 edges\n",
+      "New graph has 493 nodes and 495 edges\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 80%|████████  | 49/61 [01:58<00:12,  1.01s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Removing 808 duplicated node configs out of 8632\n",
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/retinanet.4x4.fp32.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 13867 nodes and 22162 edges\n",
+      "New graph has 995 nodes and 1045 edges\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 82%|████████▏ | 50/61 [01:59<00:09,  1.21it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Removing 798 duplicated node configs out of 6623\n",
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/inference_mlperf_ssd_1200_batch_1.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 25544 nodes and 33522 edges\n",
+      "New graph has 9294 nodes and 6926 edges\n",
+      "Removing 796 duplicated node configs out of 11560\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 84%|████████▎ | 51/61 [02:04<00:20,  2.09s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/resnet50.2x2.fp32.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 5279 nodes and 8694 edges\n",
+      "New graph has 582 nodes and 589 edges\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 85%|████████▌ | 52/61 [02:04<00:14,  1.59s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Removing 759 duplicated node configs out of 9912\n",
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/bert_pretraining.8x8.fp32.performance.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 21126 nodes and 37368 edges\n",
+      "New graph has 3698 nodes and 3437 edges\n",
+      "Removing 1920 duplicated node configs out of 18528\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 87%|████████▋ | 53/61 [02:07<00:16,  2.11s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/alexnet_train_batch_32.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 372 nodes and 597 edges\n",
+      "New graph has 73 nodes and 73 edges\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 89%|████████▊ | 54/61 [02:12<00:19,  2.75s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Removing 17807 duplicated node configs out of 47712\n",
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/mnasnet_b1_batch_128.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 7768 nodes and 13121 edges\n",
+      "New graph has 630 nodes and 633 edges\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 90%|█████████ | 55/61 [02:12<00:12,  2.01s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Removing 314 duplicated node configs out of 6344\n",
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/mlperf_ssd_1_shard_batch_8_fast_epoch.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 5358 nodes and 9631 edges\n",
+      "New graph has 933 nodes and 1030 edges\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 92%|█████████▏| 56/61 [02:13<00:07,  1.56s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Removing 917 duplicated node configs out of 7584\n",
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/transformer.4x4.fp32.performance.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 26234 nodes and 48094 edges\n",
+      "New graph has 5529 nodes and 5136 edges\n",
+      "Removing 1439 duplicated node configs out of 15256\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 93%|█████████▎| 57/61 [02:16<00:09,  2.27s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/bert_pretraining.8x16.fp16.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 21335 nodes and 37236 edges\n",
+      "New graph has 3538 nodes and 3283 edges\n",
+      "Removing 1977 duplicated node configs out of 19224\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 95%|█████████▌| 58/61 [02:20<00:07,  2.65s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/transformer.4x4.bf16.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 26906 nodes and 48823 edges\n",
+      "New graph has 5461 nodes and 5066 edges\n",
+      "Removing 1314 duplicated node configs out of 12920\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 97%|█████████▋| 59/61 [02:23<00:05,  2.85s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/resnet_v2_200_batch_32.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 19662 nodes and 35460 edges\n",
+      "New graph has 2085 nodes and 2100 edges\n",
+      "Removing 1344 duplicated node configs out of 7768\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 98%|█████████▊| 60/61 [02:24<00:02,  2.21s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/train/inception_v2_batch_8_train.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 8836 nodes and 15567 edges\n",
+      "New graph has 768 nodes and 782 edges\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 61/61 [02:25<00:00,  2.38s/it]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Removing 3740 duplicated node configs out of 13320\n",
+      "Loading valid data...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "  0%|          | 0/7 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/valid/unet_3d.4x4.bf16.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 3163 nodes and 5112 edges\n",
+      "New graph has 223 nodes and 181 edges\n",
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/valid/mlperf_bert_batch_24_2x2.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 19541 nodes and 30520 edges\n",
+      "New graph has 4807 nodes and 4498 edges\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 43%|████▎     | 3/7 [00:01<00:01,  2.98it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/valid/inception_v3_batch_128_train.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 12067 nodes and 21319 edges\n",
+      "New graph has 1059 nodes and 1084 edges\n",
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/valid/resnet50.4x4.fp16.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 5673 nodes and 9099 edges\n",
+      "New graph has 493 nodes and 495 edges\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 71%|███████▏  | 5/7 [00:01<00:00,  4.81it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/valid/resnet_v1_50_official_batch_128_bf16.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 6135 nodes and 10670 edges\n",
+      "New graph has 488 nodes and 493 edges\n",
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/valid/tf2_bert_pretrain_dynamic_batch_size.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 21664 nodes and 38485 edges\n",
+      "New graph has 3889 nodes and 3480 edges\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 86%|████████▌ | 6/7 [00:03<00:00,  1.46it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/valid/bert_pretraining.4x4.fp16.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 21335 nodes and 37236 edges\n",
+      "New graph has 3538 nodes and 3283 edges\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 7/7 [00:05<00:00,  1.35it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loading test data...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "  0%|          | 0/8 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/test/937ee0eb0d5d6151b7b8252933b5c1c9.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 5279 nodes and 8694 edges\n",
+      "New graph has 582 nodes and 589 edges\n",
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/test/e8a3a1401b5e79f66d7037e424f3b6df.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 23363 nodes and 38984 edges\n",
+      "New graph has 6140 nodes and 6482 edges\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 50%|█████     | 4/8 [00:00<00:00, 12.31it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/test/db59a991b7c607634f13570d52ce885f.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 5810 nodes and 10345 edges\n",
+      "New graph has 594 nodes and 599 edges\n",
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/test/5335ed13823b0a518ee3c79ba4425f34.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 43615 nodes and 73881 edges\n",
+      "New graph has 3142 nodes and 3089 edges\n",
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/test/cd708819d3f5103afd6460b15e74eaf3.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 490 nodes and 749 edges\n",
+      "New graph has 118 nodes and 116 edges\n",
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/test/fbaa8bb6a1aed9988281085c91065c05.npz\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 75%|███████▌  | 6/8 [00:00<00:00, 11.81it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Pruning graph...\n",
+      "Original graph has 24790 nodes and 32709 edges\n",
+      "New graph has 6411 nodes and 4774 edges\n",
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/test/3e7156ac468dfb75cf5c9615e1e5887d.npz\n",
+      "Pruning graph...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 8/8 [00:00<00:00,  9.62it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Original graph has 41522 nodes and 72902 edges\n",
+      "New graph has 6959 nodes and 6466 edges\n",
+      "/home/edu/code/google_fast_or_slow/data/npz_all/npz/layout/xla/default/test/05ae41e26dd3c4c06390371a0423233c.npz\n",
+      "Pruning graph...\n",
+      "Original graph has 43615 nodes and 73881 edges\n",
+      "New graph has 3142 nodes and 3089 edges\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "dst_dir = root / f\"{collection}_pruned\" / ctype\n",
     "for split in [\"train\", \"valid\", \"test\"]:\n",
@@ -90,7 +1383,7 @@
     "    for npz_path in tqdm(list(split_src_dir.glob(\"*.npz\"))):\n",
     "        print(npz_path)\n",
     "        data = dict(np.load(str(npz_path), allow_pickle=True))\n",
-    "        # data = prune_graph(data)\n",
+    "        data = prune_graph(data)\n",
     "        if split == \"train\":\n",
     "            data = remove_dupplicated_node_configs(data)\n",
     "        np.savez(split_dst_dir / npz_path.name, **data)"
@@ -121,7 +1414,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -131,29 +1424,79 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['edge_index',\n",
+       " 'node_feat',\n",
+       " 'node_opcode',\n",
+       " 'node_config_feat',\n",
+       " 'node_config_ids',\n",
+       " 'node_splits',\n",
+       " 'config_runtime']"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "list(data.keys())"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(100040, 20, 18)"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "data[\"node_config_feat\"].shape"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n"
+    "in_edge_index = data[\"edge_index\"][np.isin(data[\"edge_index\"], data[\"node_config_ids\"]).any(1)]\n",
+    "\n",
+    "in_node_ids = np.unique(in_edge_index)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(set(data[\"node_config_ids\"]) - set(in_node_ids))"
    ]
   },
   {

--- a/dataset.py
+++ b/dataset.py
@@ -69,7 +69,7 @@ class LayoutDataset(Dataset):
         search,
         data_folder,
         split="train",
-        max_configs=128,
+        max_configs=64,
         scaler=None,
         tgt_scaler=None,
     ):

--- a/model_args.py
+++ b/model_args.py
@@ -13,7 +13,7 @@ class ModelArguments:
         default="32,48,64,84",
         metadata={"help": "Hidden channels for graph convolutions"},
     )
-    graph_in: int = field(default=64, metadata={"help": "input graph embedding size"})
-    graph_out: int = field(default=64, metadata={"help": "output graph embedding size"})
-    hidden_dim: int = field(default=128, metadata={"help": "hidden dimension"})
+    graph_in: int = field(default=256, metadata={"help": "input graph embedding size"})
+    graph_out: int = field(default=256, metadata={"help": "output graph embedding size"})
+    hidden_dim: int = field(default=256, metadata={"help": "hidden dimension"})
     dropout: float = field(default=0.2, metadata={"help": "dropout rate"})

--- a/train.py
+++ b/train.py
@@ -12,7 +12,7 @@ from transformers.trainer_utils import get_last_checkpoint, is_main_process
 from data_args import DataArguments
 from dataset import LayoutDataset, TileDataset, layout_collate_fn, tile_collate_fn
 from engine import CustomTrainer, LayoutComputeMetricsFn, TileComputeMetricsFn
-from model import LayoutModel, TileModel
+from model import LayoutModel, TileModel, GATLayoutModel
 from model_args import ModelArguments
 from sklearn.preprocessing import StandardScaler, MinMaxScaler
 
@@ -83,7 +83,7 @@ def main():
         search=data_args.search,
         data_folder=data_args.data_folder,
         split="valid",
-        max_configs=256,
+        # max_configs=128,
     )
     val_dataset.scaler = train_dataset.scaler
     val_dataset.tgt_scaler = train_dataset.tgt_scaler
@@ -99,7 +99,7 @@ def main():
         collate_fn = tile_collate_fn
         compute_metrics = TileComputeMetricsFn(val_dataset.df)
     else:
-        model = LayoutModel(
+        model = GATLayoutModel(
             hidden_channels=[int(x) for x in model_args.hidden_channels.split(",")],
             graph_in=model_args.graph_in,
             graph_out=model_args.graph_out,


### PR DESCRIPTION
I'm first running the EDA notebook to remove dups and prune the graphs. Then I run with the following:

```
python train.py --do_train=true --do_eval=true --per_device_train_batch_size=1 --per_device_eval_batch_size=1 --learning_rate=1e-3 --warmup_ratio=0.01 --lr_scheduler_type=cosine --save_strategy=steps --save_steps=2000 --eval_steps=2000 --evaluation_strategy=steps --logging_strategy=steps --logging_steps=200 --save_total_limit=2 --load_best_model_at_end=True --optim=adamw_torch --weight_decay=1e-5 --num_train_epochs=500 --metric_for_best_model=eval_kendalltau --greater_is_better=True --dataloader_num_workers=4 --max_grad_norm=1.0 --data_type=layout --source=xla_pruned --search=default --overwrite_output_dir=True --output_dir=./outputs/ --report_to=none --load_best_model_at_end=True --hidden_channels=256,256 --fp16
```

It's still training but so far I have KT of 37% vs. 27% without the graph norm. Note that this architecture is not the best one I had found before (the prev. best KT 33% had no GN, no relu after first linear and no residual connections in the convs, hidden_channels 128 for everything -- pretty much like the class `LayoutModel` in the code). I still need to try this previous best with the GN